### PR TITLE
feat (river_admin): add workflow-specific state deletion

### DIFF
--- a/river_admin/views/state_view.py
+++ b/river_admin/views/state_view.py
@@ -2,6 +2,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from river.models import State
+from river.models.transitionmeta import TransitionMeta
 
 from river_admin.views import get, post, delete
 from river_admin.views.serializers import StateDto, CreateStateDto
@@ -33,3 +34,32 @@ def delete_it(request, pk):
     state = get_object_or_404(State.objects.all(), pk=pk)
     state.delete()
     return Response(status=HTTP_200_OK)
+
+
+@delete(r'state/delete/<int:workflow_id>/<int:pk>/')
+def delete_state_from_workflow(request, workflow_id, pk):
+    state = get_state(pk)
+    delete_transitions_from_source(workflow_id, state)
+    delete_transitions_from_destination(workflow_id, state)
+    return Response(status=HTTP_200_OK)
+
+
+def get_state(pk):
+    """
+    Get a State based on its primary key (pk)
+    """
+    return get_object_or_404(State.objects.all(), pk=pk)
+
+
+def delete_transitions_from_source(workflow_id, state):
+    """
+    Delete TransitionMeta instances where the State is the "source state"
+    """
+    TransitionMeta.objects.filter(workflow_id=workflow_id, source_state=state).delete()
+
+
+def delete_transitions_from_destination(workflow_id, state):
+    """
+    Delete TransitionMeta instances where the State is the "destination state"
+    """
+    TransitionMeta.objects.filter(workflow_id=workflow_id, destination_state=state).delete()


### PR DESCRIPTION
Implemented a feature in `state_view.py` to allow deleting a state for a specific workflow. Two helper functions `delete_transitions_from_source` and `delete_transitions_from_destination` are added to delete `TransitionMeta` instances related to the state being deleted.