### PR TITLE
fix (river_admin): Handle delete operation for protected state [FMS-2168]

### DIFF
--- a/river_admin/views/state_view.py
+++ b/river_admin/views/state_view.py
@@ -1,3 +1,4 @@
+from django.db.models import ProtectedError
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
@@ -34,7 +35,10 @@ def create_state(request):
 @delete(r'state/delete/<int:pk>/')
 def delete_state(request, pk):
     state = get_object_or_404(State.objects.all(), pk=pk)
-    state.delete()
+    try:
+        state.delete()
+    except ProtectedError as e:
+        return Response({"message": str(e)}, status=HTTP_400_BAD_REQUEST)
     return Response(status=HTTP_200_OK)
 
 


### PR DESCRIPTION
A try-except block has been added to handle delete operation in state_view.py. If a state is protected, it now returns a "HTTP_400_BAD_REQUEST" response and an accompanying error message, instead of trying to delete the state and potentially causing unexpected behavior.