### PR TITLE
feat(river_admin): Add FeatureSetting endpoints and serializer [FMS-2100]

### DIFF
--- a/river_admin/views/__init__.py
+++ b/river_admin/views/__init__.py
@@ -115,6 +115,7 @@ from .transition_view import *
 from .transition_approval_view import *
 from .workflow_object_view import *
 from .approval_view import *
+from .feature_panel_view import *
 
 @get(
     r'river-admin/', authentication_classes=[],

--- a/river_admin/views/feature_panel_view.py
+++ b/river_admin/views/feature_panel_view.py
@@ -1,0 +1,47 @@
+from rest_framework.generics import get_object_or_404
+from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
+
+from river_admin.views import get, post, put, delete
+from river.models.feature_panel import FeatureSetting
+from river_admin.views.serializers import FeatureSettingDto
+
+
+@get(r'feature_setting/get/<int:pk>/')
+def get_it(request, pk):
+    feature_setting = get_object_or_404(FeatureSetting.objects.all(), pk=pk)
+    return Response(FeatureSettingDto(feature_setting).data, status=HTTP_200_OK)
+
+
+@get(r'feature_setting/list/')
+def list_it(request):
+    return Response(FeatureSettingDto(FeatureSetting.objects.all(), many=True).data, status=HTTP_200_OK)
+
+
+@post(r'feature_setting/create/')
+def create_it(request):
+    create_feature_setting_request = FeatureSettingDto(data=request.data)
+    if create_feature_setting_request.is_valid():
+        feature_setting = create_feature_setting_request.save()
+        return Response({"id": feature_setting.id}, status=HTTP_200_OK)
+    else:
+        return Response(create_feature_setting_request.errors, status=HTTP_400_BAD_REQUEST)
+
+
+@put(r'feature_setting/update/<int:pk>/')
+def update_it(request, pk):
+    feature_setting = get_object_or_404(FeatureSetting.objects.all(), pk=pk)
+    update_feature_setting_request = FeatureSettingDto(data=request.data, instance=feature_setting)
+
+    if update_feature_setting_request.is_valid():
+        update_feature_setting_request.save()
+        return Response({"message": "Feature setting is updated"}, status=HTTP_200_OK)
+    else:
+        return Response(update_feature_setting_request.errors, status=HTTP_400_BAD_REQUEST)
+
+
+@delete(r'feature_setting/delete/<int:pk>/')
+def delete_it(request, pk):
+    feature_setting = get_object_or_404(FeatureSetting.objects.all(), pk=pk)
+    feature_setting.delete()
+    return Response(status=HTTP_200_OK)

--- a/river_admin/views/serializers.py
+++ b/river_admin/views/serializers.py
@@ -6,6 +6,8 @@ from river.models import Function, OnApprovedHook, State, TransitionApprovalMeta
 
 # Custom Usermodel support patch
 from django.contrib.auth import get_user_model
+from river.models.feature_panel import FeatureSetting
+
 User = get_user_model()
 
 from river.models.hook import AFTER, BEFORE
@@ -214,3 +216,17 @@ class TransitionApprovalDto(serializers.ModelSerializer):
 class WorkflowObjectStateDto(serializers.Serializer):
     iteration = serializers.IntegerField()
     state = StateDto()
+
+
+class FeatureSettingDto(serializers.ModelSerializer):
+    feature_display = serializers.SerializerMethodField()  # Add display field
+
+    class Meta:
+        model = FeatureSetting
+        fields = ['feature', 'feature_display', 'is_enabled']
+
+    def get_feature_display(self, obj):
+        return obj.get_feature_display()  # Get the human-readable value
+
+    def create(self, validated_data):
+        return FeatureSetting.objects.get_or_create(**validated_data)[0]


### PR DESCRIPTION
This commit adds a new serializer, FeatureSettingDto, in serializers.py for the FeatureSetting model in the river_admin application. It also introduces new view endpoints in feature_panel_view.py for creating, reading, updating and deleting feature settings. These endpoints have been included in river_admin's __init__.py file.