### PR TITLE
feat(river_admin): add toggle for username column in admin list [FMS-…

### DIFF
--- a/river_admin/__init__.py
+++ b/river_admin/__init__.py
@@ -1,5 +1,3 @@
-from river.models.feature_panel import FeatureSetting
-
 from river_admin.site import Site
 
 
@@ -34,6 +32,7 @@ class RiverAdmin(object):
 
     @classproperty
     def admin_list_displays(cls):
+        from river.models.feature_panel import FeatureSetting
         if not FeatureSetting.objects.filter(
                 feature=FeatureSetting.FeatureChoices.USERNAME_COLUMN, is_enabled=True
         ).exists():


### PR DESCRIPTION
…2100]

The code now imports FeatureSetting model and uses it to check if a "USERNAME_COLUMN" feature is enabled. If it's turned off, the "username" display will not be included in the admin list displays. This feature allows for a more customizable admin list.