### PR TITLE
feat(river_admin): add toggle for username column in admin list [FMS-2100]

### DIFF
--- a/river_admin/__init__.py
+++ b/river_admin/__init__.py
@@ -35,7 +35,7 @@ class RiverAdmin(object):
         from river.models.feature_panel import FeatureSetting
         if hasattr(cls, 'list_displays') and isinstance(cls.list_displays, list):
             if not FeatureSetting.objects.filter(
-                    feature=FeatureSetting.FeatureChoices.USERNAME_COLUMN, is_enabled=True
+                    feature='username_column', is_enabled=True
             ).exists():
                 cls.list_displays = [display for display in cls.list_displays if display != "username"]
             return cls.list_displays or ["pk", getattr(cls, '_field_name', 'default_field_name')]


### PR DESCRIPTION
The code now imports FeatureSetting model and uses it to check if a "USERNAME_COLUMN" feature is enabled. If it's turned off, the "username" display will not be included in the admin list displays. This feature allows for a more customizable admin list.