### PR TITLE
feat (river_admin): Improve state listing by adding slug filter [FMS-2348]

### DIFF
--- a/river_admin/views/state_view.py
+++ b/river_admin/views/state_view.py
@@ -18,7 +18,11 @@ def get_state(request, pk):
 
 @get(r'state/list/')
 def list_states(request):
-    states = State.objects.all()
+    slug = request.GET.get('slug').lower()
+    if slug:
+        states = State.objects.filter(slug__contains=slug)
+    else:
+        states = State.objects.all()
     return Response(StateDto(states, many=True).data, status=HTTP_200_OK)
 
 


### PR DESCRIPTION
The state_view.py file was updated to improve the search functionality of state listing. Instead of returning all states, the list_states function now uses a keyword ('slug') from the request to filter the states if available. The 'slug' keyword is used to search within slugs of the states. If no slug is provided, it will return all states as before.