### PR TITLE
feat (river_admin): Improve state listing by adding slug filter [FMS-2348]

### DIFF
--- a/river_admin/views/state_view.py
+++ b/river_admin/views/state_view.py
@@ -18,7 +18,7 @@ def get_state(request, pk):
 
 @get(r'state/list/')
 def list_states(request):
-    slug = request.GET.get('slug').lower()
+    slug = request.GET.get('slug').lower() if request.GET.get('slug') else None
     if slug:
         states = State.objects.filter(slug__contains=slug)
     else:


### PR DESCRIPTION
The state_view.py file was updated to improve the search functionality of state listing. Instead of returning all states, the list_states function now uses a keyword ('slug') from the request to filter the states if available. The 'slug' keyword is used to search within slugs of the states. If no slug is provided, it will return all states as before.