### PR TITLE
feat (river_admin): Add title and description fields to Workflow serializer [FMS-2349]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ mock==2.0.0
 pyhamcrest==1.9.0
 djangorestframework
 django-cors-headers
-django-river @ git+https://github.com/tamhub/django-river@8d287d6bda149b5b0f7152d80c79045fec180641
+django-river @ git+https://github.com/tamhub/django-river@472d6390f322c430b3bf96d7263a174b63939440
 django-heroku
 psycopg2
 gunicorn

--- a/river_admin/views/serializers.py
+++ b/river_admin/views/serializers.py
@@ -95,7 +95,7 @@ class WorkflowStateFieldDto(serializers.Serializer):
 class CreateWorkflowDto(serializers.ModelSerializer):
     class Meta:
         model = Workflow
-        fields = ["content_type", "field_name", "initial_state"]
+        fields = ["content_type", "field_name", "initial_state", "title", "description"]
 
 
 # TRANSITION META


### PR DESCRIPTION
Updated the 'CreateWorkflowDto' serializer in the 'river_admin' app to include 'title' and 'description' fields in addition to 'content_type', 'field_name', and 'initial_state'. This change accommodates the inclusion of more descriptive metadata for each workflow. The 'django-river' dependency in requirements.txt was also updated to a newer commit.